### PR TITLE
Configure static file handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,9 @@ ENV DJANGO_DB_HOST=db
 ENV DJANGO_DB_PORT=5432
 
 # Device registry config
-ENV MEDIA_ROOT=/media
 ENV DJANGO_SETTINGS_MODULE=deviceregistry.settings
+ENV MEDIA_ROOT=/media
+ENV STATIC_ROOT=/static
 
 COPY entrypoint.sh /
 
@@ -43,6 +44,8 @@ COPY --chown=app:app mittaridatapumppu-deviceregistry/ .
 # Support Arbitrary User IDs
 RUN chgrp -R 0 /home/app && \
   chmod -R g+rwX /home/app
+
+RUN python manage.py collectstatic --noinput
 
 USER app
 

--- a/mittaridatapumppu-deviceregistry/deviceregistry/settings.py
+++ b/mittaridatapumppu-deviceregistry/deviceregistry/settings.py
@@ -147,7 +147,8 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.2/howto/static-files/
 
-STATIC_URL = "static/"
+STATIC_ROOT = env("STATIC_ROOT", default="/static")
+STATIC_URL = env("STATIC_URL", default="/static/")
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field


### PR DESCRIPTION
Collect static files when building the image and place them under `/static` by default.